### PR TITLE
Updated check_passwords function to be compatible with php5.4+

### DIFF
--- a/iuwpcas.php
+++ b/iuwpcas.php
@@ -306,7 +306,7 @@ if ( !class_exists('IUCASAuthentication') ) {
 	     * @param $pass1 string
 	     * @param $pass2 string
 	     */
-		function check_passwords( $user, $pass1, $pass2 ) {
+		function check_passwords( $user, &$pass1, &$pass2 ) {
 			$random_password = substr( md5( uniqid( microtime( ))), 0, 8 );
 			$pass1=$pass2=$random_password;
 		}


### PR DESCRIPTION
Webserve will be depreciating and removing all versions of php prior to 5.6. This plugin will no longer work on webserve unless this patch is applied. This is the same change that was included in issue #12.